### PR TITLE
feat: Add 3-section user survey to registration modal

### DIFF
--- a/SURVEY_IMPLEMENTATION.md
+++ b/SURVEY_IMPLEMENTATION.md
@@ -1,0 +1,109 @@
+# PAWhere Survey Implementation
+
+## Overview
+The PAWhere registration modal now includes a comprehensive 3-section survey to collect valuable user insights and feedback. This implementation allows the team to better understand user needs and tailor the product accordingly.
+
+## Survey Sections
+
+### Section 1: Background Information
+- Pet ownership status (Yes/No)
+- Pet type(s) owned (Dog, Cat, Other with custom specification)
+- Outdoor frequency (Rarely/Sometimes/Often)
+- Previous lost pet experience
+- Recovery method details (if applicable)
+
+### Section 2: Current Solutions & Pain Points
+- Current tracking solution usage
+- Solution details specification
+- Primary safety concerns (Getting lost, Stolen, Injured, Other)
+- Current safety monitoring methods (open text)
+
+### Section 3: Expectations for PAWhere
+- Most important features (GPS accuracy, Battery life, Geofencing, Device size, App usability, Price) - max 2 selections
+- Expected challenges (Setup complexity, Battery charging, Signal coverage, Pet comfort, Other)
+- Usefulness rating scale (1-10)
+- Desired feature suggestions (open text)
+
+## Technical Implementation
+
+### Frontend Changes
+- **File**: `client/src/components/registration-modal.tsx`
+- Added comprehensive form validation using Zod schema
+- Implemented conditional logic (questions appear based on previous answers)
+- Enhanced UI with proper checkbox and textarea components
+- Increased modal size to accommodate all questions
+- Added clear section headers and question numbering
+
+### Backend Schema Updates
+- **File**: `shared/schema.ts`
+- Extended `registrations` table with JSONB fields for array data
+- Added text fields for single responses
+- Added integer field for rating scale
+- Updated schema exports and types
+
+### Database Migration
+- **File**: `server/migrate.ts` - Updated for new installations
+- **File**: `server/migrate-survey-fields.ts` - Migration for existing databases
+- **Command**: `npm run db:migrate-survey` - Run survey field migration
+
+### Storage Layer Updates
+- **File**: `server/storage-types.d.ts` - Updated interfaces
+- **File**: `server/postgres-storage.ts` - Enhanced data handling
+- All survey fields now properly stored and retrieved
+
+## Data Storage Structure
+
+The survey responses are stored in the following database columns:
+
+```sql
+-- Section 1: Background Information
+owns_pet TEXT
+pet_type JSONB                    -- Array of strings
+pet_type_other TEXT
+outdoor_frequency TEXT
+has_lost_pet TEXT
+how_found_pet TEXT
+
+-- Section 2: Current Solutions & Pain Points
+uses_tracking_solution TEXT
+tracking_solution_details TEXT
+safety_worries JSONB             -- Array of strings
+safety_worries_other TEXT
+current_safety_methods TEXT
+
+-- Section 3: Expectations for PAWhere
+important_features JSONB         -- Array of strings
+expected_challenges JSONB        -- Array of strings
+expected_challenges_other TEXT
+usefulness_rating INTEGER        -- 1-10 scale
+wish_feature TEXT
+```
+
+## Usage Instructions
+
+### For New Installations
+1. Run `npm run db:migrate` to create tables with survey fields
+
+### For Existing Installations
+1. Run `npm run db:migrate-survey` to add survey fields to existing tables
+
+### Accessing Survey Data
+Survey responses are included in all registration API responses and can be accessed through the existing `/api/register` endpoints.
+
+## UI/UX Features
+
+- **Responsive Design**: Works on both desktop and mobile
+- **Conditional Logic**: Questions appear based on user responses
+- **Validation**: Required fields are enforced
+- **User-Friendly**: Clear instructions and intuitive interface
+- **Accessibility**: Proper labels and keyboard navigation
+
+## Benefits for Product Development
+
+1. **User Segmentation**: Understand different user types and their needs
+2. **Feature Prioritization**: Identify most valued features
+3. **Pain Point Analysis**: Address common concerns proactively
+4. **Market Validation**: Gauge product-market fit
+5. **Competitive Intelligence**: Learn about current solutions users employ
+
+This comprehensive survey implementation provides valuable insights while maintaining a smooth user experience during the registration process.

--- a/client/src/components/registration-modal.tsx
+++ b/client/src/components/registration-modal.tsx
@@ -20,6 +20,8 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Textarea } from "@/components/ui/textarea";
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
 
@@ -27,6 +29,28 @@ const registrationSchema = z.object({
   email: z.string().email("Please enter a valid email address"),
   phone: z.string().optional(),
   isVip: z.boolean().default(false),
+  
+  // Section 1: Background Information
+  ownsPet: z.enum(["yes", "no"], { required_error: "Please select an option" }),
+  petType: z.array(z.string()).optional(),
+  petTypeOther: z.string().optional(),
+  outdoorFrequency: z.enum(["rarely", "sometimes", "often"]).optional(),
+  hasLostPet: z.enum(["yes", "no"]).optional(),
+  howFoundPet: z.string().optional(),
+  
+  // Section 2: Current Solutions & Pain Points
+  usesTrackingSolution: z.enum(["yes", "no"]).optional(),
+  trackingSolutionDetails: z.string().optional(),
+  safetyWorries: z.array(z.string()).optional(),
+  safetyWorriesOther: z.string().optional(),
+  currentSafetyMethods: z.string().optional(),
+  
+  // Section 3: Expectations for PAWhere
+  importantFeatures: z.array(z.string()).optional(),
+  expectedChallenges: z.array(z.string()).optional(),
+  expectedChallengesOther: z.string().optional(),
+  usefulnessRating: z.number().min(1).max(10).optional(),
+  wishFeature: z.string().optional(),
 });
 
 type RegistrationData = z.infer<typeof registrationSchema>;
@@ -49,6 +73,22 @@ export function RegistrationModal({ isOpen, onClose, trigger, isVip = false }: R
       email: "",
       phone: "",
       isVip: isVip,
+      ownsPet: undefined,
+      petType: [],
+      petTypeOther: "",
+      outdoorFrequency: undefined,
+      hasLostPet: undefined,
+      howFoundPet: "",
+      usesTrackingSolution: undefined,
+      trackingSolutionDetails: "",
+      safetyWorries: [],
+      safetyWorriesOther: "",
+      currentSafetyMethods: "",
+      importantFeatures: [],
+      expectedChallenges: [],
+      expectedChallengesOther: "",
+      usefulnessRating: undefined,
+      wishFeature: "",
     },
   });
 
@@ -64,7 +104,9 @@ export function RegistrationModal({ isOpen, onClose, trigger, isVip = false }: R
       });
       form.reset();
       setOpen(false);
-      if (onClose) onClose();
+      if (onClose) {
+        onClose();
+      }
       queryClient.invalidateQueries({ queryKey: ["/api/register"] });
     },
     onError: (error: any) => {
@@ -97,7 +139,7 @@ export function RegistrationModal({ isOpen, onClose, trigger, isVip = false }: R
   };
 
   const dialogContent = (
-    <DialogContent className="max-w-md">
+    <DialogContent className="max-w-3xl max-h-[95vh] overflow-y-auto">
       <DialogHeader>
         <div className="text-center mb-6">
           <div className="bg-primary-yellow rounded-full w-16 h-16 flex items-center justify-center mx-auto mb-4">
@@ -109,51 +151,504 @@ export function RegistrationModal({ isOpen, onClose, trigger, isVip = false }: R
           <p className="text-gray-600">
             {isVip 
               ? "Get exclusive early access and help shape the future of pet safety" 
-              : "Get early access to PAWhere and keep your pet safe"
+              : "Get early access to PAWhere and help us understand your needs"
             }
+          </p>
+          <p className="text-sm text-gray-500 mt-2">
+            Please take a moment to answer a few questions so we can better tailor PAWhere to your needs.
           </p>
         </div>
       </DialogHeader>
 
       <Form {...form}>
-        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
-          <FormField
-            control={form.control}
-            name="email"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Email Address</FormLabel>
-                <FormControl>
-                  <Input
-                    type="email"
-                    placeholder="your.email@example.com"
-                    className="rounded-xl focus:ring-primary-yellow"
-                    {...field}
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+          {/* Contact Information */}
+          <div className="space-y-4">
+            <h3 className="text-lg font-semibold text-gray-900">Contact Information</h3>
+            
+            <FormField
+              control={form.control}
+              name="email"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Email Address</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="email"
+                      placeholder="your.email@example.com"
+                      className="rounded-xl focus:ring-primary-yellow"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
 
-          <FormField
-            control={form.control}
-            name="phone"
-            render={({ field }) => (
-              <FormItem>
-                <FormLabel>Phone Number (Optional)</FormLabel>
-                <FormControl>
-                  <Input
-                    type="tel"
-                    placeholder="(+855) 123-4567"
-                    className="rounded-xl focus:ring-primary-yellow"
-                    {...field}
+            <FormField
+              control={form.control}
+              name="phone"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Phone Number (Optional)</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="tel"
+                      placeholder="(+855) 123-4567"
+                      className="rounded-xl focus:ring-primary-yellow"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+
+          {/* Section 1: Background Information */}
+          <div className="space-y-4 border-t pt-6">
+            <h3 className="text-lg font-semibold text-gray-900">Section 1: Background Information</h3>
+            
+            <FormField
+              control={form.control}
+              name="ownsPet"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>1. Do you currently own a pet?</FormLabel>
+                  <FormControl>
+                    <div className="flex gap-4">
+                      <label className="flex items-center gap-2 cursor-pointer">
+                        <input
+                          type="radio"
+                          value="yes"
+                          checked={field.value === "yes"}
+                          onChange={() => field.onChange("yes")}
+                          className="text-primary-yellow"
+                        />
+                        Yes
+                      </label>
+                      <label className="flex items-center gap-2 cursor-pointer">
+                        <input
+                          type="radio"
+                          value="no"
+                          checked={field.value === "no"}
+                          onChange={() => field.onChange("no")}
+                          className="text-primary-yellow"
+                        />
+                        No
+                      </label>
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {form.watch("ownsPet") === "yes" && (
+              <>
+                <FormField
+                  control={form.control}
+                  name="petType"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>2. If yes, what type of pet(s) do you own?</FormLabel>
+                      <FormControl>
+                        <div className="space-y-2">
+                          {["Dog", "Cat"].map((type) => (
+                            <label key={type} className="flex items-center gap-2 cursor-pointer">
+                              <Checkbox
+                                checked={field.value?.includes(type) || false}
+                                onCheckedChange={(checked) => {
+                                  if (checked) {
+                                    field.onChange([...(field.value || []), type]);
+                                  } else {
+                                    field.onChange(field.value?.filter(v => v !== type) || []);
+                                  }
+                                }}
+                              />
+                              {type}
+                            </label>
+                          ))}
+                          <div className="flex items-center gap-2">
+                            <Checkbox
+                              checked={field.value?.includes("other") || false}
+                              onCheckedChange={(checked) => {
+                                if (checked) {
+                                  field.onChange([...(field.value || []), "other"]);
+                                } else {
+                                  field.onChange(field.value?.filter(v => v !== "other") || []);
+                                }
+                              }}
+                            />
+                            <span>Other:</span>
+                            <Input
+                              placeholder="Specify"
+                              className="w-32 h-8 text-sm"
+                              {...form.register("petTypeOther")}
+                            />
+                          </div>
+                        </div>
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="outdoorFrequency"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>3. How often does your pet go outdoors?</FormLabel>
+                      <FormControl>
+                        <div className="space-y-2">
+                          {[
+                            { value: "rarely", label: "Rarely (mostly indoors)" },
+                            { value: "sometimes", label: "Sometimes (walks / play)" },
+                            { value: "often", label: "Often (roams freely)" }
+                          ].map((option) => (
+                            <label key={option.value} className="flex items-center gap-2 cursor-pointer">
+                              <input
+                                type="radio"
+                                value={option.value}
+                                checked={field.value === option.value}
+                                onChange={() => field.onChange(option.value)}
+                                className="text-primary-yellow"
+                              />
+                              {option.label}
+                            </label>
+                          ))}
+                        </div>
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="hasLostPet"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>4. Have you ever lost your pet before?</FormLabel>
+                      <FormControl>
+                        <div className="flex gap-4">
+                          <label className="flex items-center gap-2 cursor-pointer">
+                            <input
+                              type="radio"
+                              value="yes"
+                              checked={field.value === "yes"}
+                              onChange={() => field.onChange("yes")}
+                              className="text-primary-yellow"
+                            />
+                            Yes
+                          </label>
+                          <label className="flex items-center gap-2 cursor-pointer">
+                            <input
+                              type="radio"
+                              value="no"
+                              checked={field.value === "no"}
+                              onChange={() => field.onChange("no")}
+                              className="text-primary-yellow"
+                            />
+                            No
+                          </label>
+                        </div>
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                {form.watch("hasLostPet") === "yes" && (
+                  <FormField
+                    control={form.control}
+                    name="howFoundPet"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>5. If yes, how did you find your pet (or did you)?</FormLabel>
+                        <FormControl>
+                          <Textarea
+                            placeholder="Please describe how you found your pet..."
+                            className="rounded-xl focus:ring-primary-yellow"
+                            {...field}
+                          />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
                   />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
+                )}
+              </>
             )}
-          />
+          </div>
+
+          {/* Section 2: Current Solutions & Pain Points */}
+          <div className="space-y-4 border-t pt-6">
+            <h3 className="text-lg font-semibold text-gray-900">Section 2: Current Solutions & Pain Points</h3>
+            
+            <FormField
+              control={form.control}
+              name="usesTrackingSolution"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>6. Do you currently use any tracking solution for your pet?</FormLabel>
+                  <FormControl>
+                    <div className="flex gap-4">
+                      <label className="flex items-center gap-2 cursor-pointer">
+                        <input
+                          type="radio"
+                          value="yes"
+                          checked={field.value === "yes"}
+                          onChange={() => field.onChange("yes")}
+                          className="text-primary-yellow"
+                        />
+                        Yes
+                      </label>
+                      <label className="flex items-center gap-2 cursor-pointer">
+                        <input
+                          type="radio"
+                          value="no"
+                          checked={field.value === "no"}
+                          onChange={() => field.onChange("no")}
+                          className="text-primary-yellow"
+                        />
+                        No
+                      </label>
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            {form.watch("usesTrackingSolution") === "yes" && (
+              <FormField
+                control={form.control}
+                name="trackingSolutionDetails"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Please specify:</FormLabel>
+                    <FormControl>
+                      <Input
+                        placeholder="e.g., GPS collar, microchip, etc."
+                        className="rounded-xl focus:ring-primary-yellow"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
+
+            <FormField
+              control={form.control}
+              name="safetyWorries"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>7. What worries you most about your pet's safety?</FormLabel>
+                  <FormControl>
+                    <div className="space-y-2">
+                      {["Getting lost", "Stolen", "Injured while outside"].map((worry) => (
+                        <label key={worry} className="flex items-center gap-2 cursor-pointer">
+                          <Checkbox
+                            checked={field.value?.includes(worry) || false}
+                            onCheckedChange={(checked) => {
+                              if (checked) {
+                                field.onChange([...(field.value || []), worry]);
+                              } else {
+                                field.onChange(field.value?.filter(v => v !== worry) || []);
+                              }
+                            }}
+                          />
+                          {worry}
+                        </label>
+                      ))}
+                      <div className="flex items-center gap-2">
+                        <Checkbox
+                          checked={field.value?.includes("other") || false}
+                          onCheckedChange={(checked) => {
+                            if (checked) {
+                              field.onChange([...(field.value || []), "other"]);
+                            } else {
+                              field.onChange(field.value?.filter(v => v !== "other") || []);
+                            }
+                          }}
+                        />
+                        <span>Other:</span>
+                        <Input
+                          placeholder="Specify"
+                          className="flex-1 h-8 text-sm"
+                          {...form.register("safetyWorriesOther")}
+                        />
+                      </div>
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="currentSafetyMethods"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>8. What do you currently do to monitor or keep your pet safe?</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder="Please describe your current methods..."
+                      className="rounded-xl focus:ring-primary-yellow"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+
+          {/* Section 3: Expectations for PAWhere */}
+          <div className="space-y-4 border-t pt-6">
+            <h3 className="text-lg font-semibold text-gray-900">Section 3: Expectations for PAWhere</h3>
+            
+            <FormField
+              control={form.control}
+              name="importantFeatures"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>9. Which feature is MOST important to you? (Select up to 2)</FormLabel>
+                  <FormControl>
+                    <div className="space-y-2">
+                      {[
+                        "GPS tracking accuracy",
+                        "Long battery life",
+                        "Geofencing alerts (when pet leaves safe zone)",
+                        "Small & comfortable device size",
+                        "Mobile app usability",
+                        "Price"
+                      ].map((feature) => (
+                        <label key={feature} className="flex items-center gap-2 cursor-pointer">
+                          <Checkbox
+                            checked={field.value?.includes(feature) || false}
+                            onCheckedChange={(checked) => {
+                              if (checked && (field.value?.length || 0) < 2) {
+                                field.onChange([...(field.value || []), feature]);
+                              } else if (!checked) {
+                                field.onChange(field.value?.filter(v => v !== feature) || []);
+                              }
+                            }}
+                            disabled={(field.value?.length || 0) >= 2 && !field.value?.includes(feature)}
+                          />
+                          {feature}
+                        </label>
+                      ))}
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="expectedChallenges"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>10. What challenges do you expect from using a device like PAWhere?</FormLabel>
+                  <FormControl>
+                    <div className="space-y-2">
+                      {[
+                        "Complicated setup",
+                        "Battery charging too often",
+                        "Weak signal or GPS coverage",
+                        "Not comfortable for my pet"
+                      ].map((challenge) => (
+                        <label key={challenge} className="flex items-center gap-2 cursor-pointer">
+                          <Checkbox
+                            checked={field.value?.includes(challenge) || false}
+                            onCheckedChange={(checked) => {
+                              if (checked) {
+                                field.onChange([...(field.value || []), challenge]);
+                              } else {
+                                field.onChange(field.value?.filter(v => v !== challenge) || []);
+                              }
+                            }}
+                          />
+                          {challenge}
+                        </label>
+                      ))}
+                      <div className="flex items-center gap-2">
+                        <Checkbox
+                          checked={field.value?.includes("other") || false}
+                          onCheckedChange={(checked) => {
+                            if (checked) {
+                              field.onChange([...(field.value || []), "other"]);
+                            } else {
+                              field.onChange(field.value?.filter(v => v !== "other") || []);
+                            }
+                          }}
+                        />
+                        <span>Other:</span>
+                        <Input
+                          placeholder="Specify"
+                          className="flex-1 h-8 text-sm"
+                          {...form.register("expectedChallengesOther")}
+                        />
+                      </div>
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="usefulnessRating"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>11. On a scale of 1-10, how useful do you expect PAWhere to be for you? (1 = Not useful at all, 10 = Extremely useful)</FormLabel>
+                  <FormControl>
+                    <div className="flex gap-2 flex-wrap">
+                      {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((rating) => (
+                        <label key={rating} className="flex items-center gap-1 cursor-pointer">
+                          <input
+                            type="radio"
+                            value={rating}
+                            checked={field.value === rating}
+                            onChange={() => field.onChange(rating)}
+                            className="text-primary-yellow"
+                          />
+                          {rating}
+                        </label>
+                      ))}
+                    </div>
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <FormField
+              control={form.control}
+              name="wishFeature"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>12. What is one feature you wish PAWhere could have to make it perfect for you?</FormLabel>
+                  <FormControl>
+                    <Textarea
+                      placeholder="Describe your ideal feature..."
+                      className="rounded-xl focus:ring-primary-yellow"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
 
           <Button
             type="submit"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "cross-env NODE_ENV=production node dist/index.js",
     "check": "tsc",
     "db:push": "drizzle-kit push",
-    "db:migrate": "tsx server/migrate-db.ts"
+    "db:migrate": "tsx server/migrate-db.ts",
+    "db:migrate-survey": "tsx server/migrate-survey-fields.ts"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/server/migrate-survey-fields.ts
+++ b/server/migrate-survey-fields.ts
@@ -1,0 +1,38 @@
+import { db } from './db';
+import { sql } from 'drizzle-orm';
+
+async function addSurveyFields() {
+  console.log('Adding survey fields to registrations table...');
+  
+  try {
+    // Add new survey fields to existing registrations table
+    await db.execute(sql`
+      ALTER TABLE registrations 
+      ADD COLUMN IF NOT EXISTS owns_pet TEXT,
+      ADD COLUMN IF NOT EXISTS pet_type JSONB,
+      ADD COLUMN IF NOT EXISTS pet_type_other TEXT,
+      ADD COLUMN IF NOT EXISTS outdoor_frequency TEXT,
+      ADD COLUMN IF NOT EXISTS has_lost_pet TEXT,
+      ADD COLUMN IF NOT EXISTS how_found_pet TEXT,
+      ADD COLUMN IF NOT EXISTS uses_tracking_solution TEXT,
+      ADD COLUMN IF NOT EXISTS tracking_solution_details TEXT,
+      ADD COLUMN IF NOT EXISTS safety_worries JSONB,
+      ADD COLUMN IF NOT EXISTS safety_worries_other TEXT,
+      ADD COLUMN IF NOT EXISTS current_safety_methods TEXT,
+      ADD COLUMN IF NOT EXISTS important_features JSONB,
+      ADD COLUMN IF NOT EXISTS expected_challenges JSONB,
+      ADD COLUMN IF NOT EXISTS expected_challenges_other TEXT,
+      ADD COLUMN IF NOT EXISTS usefulness_rating INTEGER,
+      ADD COLUMN IF NOT EXISTS wish_feature TEXT
+    `);
+
+    console.log('Survey fields added successfully!');
+  } catch (error) {
+    console.error('Migration error:', error);
+    throw error;
+  }
+}
+
+addSurveyFields()
+  .catch(console.error)
+  .finally(() => process.exit());

--- a/server/migrate.ts
+++ b/server/migrate.ts
@@ -22,6 +22,29 @@ async function runMigrations() {
         email TEXT NOT NULL,
         phone TEXT,
         is_vip BOOLEAN DEFAULT false,
+        
+        -- Section 1: Background Information
+        owns_pet TEXT,
+        pet_type JSONB,
+        pet_type_other TEXT,
+        outdoor_frequency TEXT,
+        has_lost_pet TEXT,
+        how_found_pet TEXT,
+        
+        -- Section 2: Current Solutions & Pain Points
+        uses_tracking_solution TEXT,
+        tracking_solution_details TEXT,
+        safety_worries JSONB,
+        safety_worries_other TEXT,
+        current_safety_methods TEXT,
+        
+        -- Section 3: Expectations for PAWhere
+        important_features JSONB,
+        expected_challenges JSONB,
+        expected_challenges_other TEXT,
+        usefulness_rating INTEGER,
+        wish_feature TEXT,
+        
         created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
       )
     `);

--- a/server/postgres-storage.ts
+++ b/server/postgres-storage.ts
@@ -11,6 +11,29 @@ const toRegistration = (dbReg: any): Registration => ({
   email: dbReg.email,
   phone: dbReg.phone ?? null,
   isVip: dbReg.isVip ?? false,
+  
+  // Section 1: Background Information
+  ownsPet: dbReg.ownsPet ?? null,
+  petType: dbReg.petType ?? null,
+  petTypeOther: dbReg.petTypeOther ?? null,
+  outdoorFrequency: dbReg.outdoorFrequency ?? null,
+  hasLostPet: dbReg.hasLostPet ?? null,
+  howFoundPet: dbReg.howFoundPet ?? null,
+  
+  // Section 2: Current Solutions & Pain Points
+  usesTrackingSolution: dbReg.usesTrackingSolution ?? null,
+  trackingSolutionDetails: dbReg.trackingSolutionDetails ?? null,
+  safetyWorries: dbReg.safetyWorries ?? null,
+  safetyWorriesOther: dbReg.safetyWorriesOther ?? null,
+  currentSafetyMethods: dbReg.currentSafetyMethods ?? null,
+  
+  // Section 3: Expectations for PAWhere
+  importantFeatures: dbReg.importantFeatures ?? null,
+  expectedChallenges: dbReg.expectedChallenges ?? null,
+  expectedChallengesOther: dbReg.expectedChallengesOther ?? null,
+  usefulnessRating: dbReg.usefulnessRating ?? null,
+  wishFeature: dbReg.wishFeature ?? null,
+  
   createdAt: dbReg.createdAt ?? new Date()
 });
 
@@ -45,14 +68,8 @@ export class PostgresStorage implements IStorage {
     
     console.log("Database returned:", registration);
     
-    // Ensure we return a properly typed Registration object
-    return {
-      id: registration.id,
-      email: registration.email,
-      phone: registration.phone,
-      isVip: registration.isVip ?? false,
-      createdAt: registration.createdAt ?? new Date()
-    };
+    // Return properly typed Registration object with all survey fields
+    return toRegistration(registration);
   }
 
   async getRegistrations() {

--- a/server/storage-types.d.ts
+++ b/server/storage-types.d.ts
@@ -14,6 +14,29 @@ export interface Registration {
   email: string;
   phone: string | null;
   isVip: boolean;
+  
+  // Section 1: Background Information
+  ownsPet: string | null;
+  petType: string[] | null;
+  petTypeOther: string | null;
+  outdoorFrequency: string | null;
+  hasLostPet: string | null;
+  howFoundPet: string | null;
+  
+  // Section 2: Current Solutions & Pain Points
+  usesTrackingSolution: string | null;
+  trackingSolutionDetails: string | null;
+  safetyWorries: string[] | null;
+  safetyWorriesOther: string | null;
+  currentSafetyMethods: string | null;
+  
+  // Section 3: Expectations for PAWhere
+  importantFeatures: string[] | null;
+  expectedChallenges: string[] | null;
+  expectedChallengesOther: string | null;
+  usefulnessRating: number | null;
+  wishFeature: string | null;
+  
   createdAt: Date;
 }
 
@@ -21,6 +44,28 @@ export interface InsertRegistration {
   email: string;
   phone?: string | null;
   isVip?: boolean;
+  
+  // Section 1: Background Information
+  ownsPet?: string | null;
+  petType?: string[] | null;
+  petTypeOther?: string | null;
+  outdoorFrequency?: string | null;
+  hasLostPet?: string | null;
+  howFoundPet?: string | null;
+  
+  // Section 2: Current Solutions & Pain Points
+  usesTrackingSolution?: string | null;
+  trackingSolutionDetails?: string | null;
+  safetyWorries?: string[] | null;
+  safetyWorriesOther?: string | null;
+  currentSafetyMethods?: string | null;
+  
+  // Section 3: Expectations for PAWhere
+  importantFeatures?: string[] | null;
+  expectedChallenges?: string[] | null;
+  expectedChallengesOther?: string | null;
+  usefulnessRating?: number | null;
+  wishFeature?: string | null;
 }
 
 export interface IStorage {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,5 +1,5 @@
 import { sql } from "drizzle-orm";
-import { pgTable, text, varchar, boolean, timestamp } from "drizzle-orm/pg-core";
+import { pgTable, text, varchar, boolean, timestamp, jsonb, integer } from "drizzle-orm/pg-core";
 import { createInsertSchema } from "drizzle-zod";
 import { z } from "zod";
 
@@ -14,6 +14,29 @@ export const registrations = pgTable("registrations", {
   email: text("email").notNull(),
   phone: text("phone"),
   isVip: boolean("is_vip").default(false),
+  
+  // Section 1: Background Information
+  ownsPet: text("owns_pet"), // "yes" | "no"
+  petType: jsonb("pet_type").$type<string[]>(), // array of pet types
+  petTypeOther: text("pet_type_other"),
+  outdoorFrequency: text("outdoor_frequency"), // "rarely" | "sometimes" | "often"
+  hasLostPet: text("has_lost_pet"), // "yes" | "no"
+  howFoundPet: text("how_found_pet"),
+  
+  // Section 2: Current Solutions & Pain Points
+  usesTrackingSolution: text("uses_tracking_solution"), // "yes" | "no"
+  trackingSolutionDetails: text("tracking_solution_details"),
+  safetyWorries: jsonb("safety_worries").$type<string[]>(), // array of worries
+  safetyWorriesOther: text("safety_worries_other"),
+  currentSafetyMethods: text("current_safety_methods"),
+  
+  // Section 3: Expectations for PAWhere
+  importantFeatures: jsonb("important_features").$type<string[]>(), // array of features
+  expectedChallenges: jsonb("expected_challenges").$type<string[]>(), // array of challenges
+  expectedChallengesOther: text("expected_challenges_other"),
+  usefulnessRating: integer("usefulness_rating"), // 1-10
+  wishFeature: text("wish_feature"),
+  
   createdAt: timestamp("created_at").defaultNow(),
 });
 
@@ -22,10 +45,9 @@ export const insertUserSchema = createInsertSchema(users).pick({
   password: true,
 });
 
-export const insertRegistrationSchema = createInsertSchema(registrations).pick({
-  email: true,
-  phone: true,
-  isVip: true,
+export const insertRegistrationSchema = createInsertSchema(registrations).omit({
+  id: true,
+  createdAt: true,
 });
 
 export type InsertUser = z.infer<typeof insertUserSchema>;


### PR DESCRIPTION
Implement comprehensive survey with 12 questions covering:
- Background information (pet ownership, outdoor frequency, lost pet experience)
- Current solutions & pain points (tracking usage, safety worries)
- Pawhere expectation includes update database schema

## Summary by Sourcery

Introduce a three-section, twelve-question user survey into the registration flow and persist responses across frontend and backend.

New Features:
- Add 12-question survey in registration modal covering background, current solutions & pain points, and PAWhere expectations
- Implement conditional display logic and section headers to guide users through the survey

Enhancements:
- Extend Zod validation schema and default form values to include all survey fields
- Increase modal size and update UI text to accommodate survey with improved layout and instructions
- Update shared database schema, storage types, and storage layer to store and retrieve survey responses

Build:
- Add "db:migrate-survey" npm script to apply survey field migrations

Deployment:
- Provide migration script (server/migrate-survey-fields.ts) to add survey fields to existing databases

Documentation:
- Add SURVEY_IMPLEMENTATION.md with overview, implementation details, and usage instructions for the new survey