### PR TITLE
changed neon account and fixed database issues

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,10 @@
 # Database Configuration (Optional - uses in-memory storage by default)
-DATABASE_URL=postgresql://neondb_owner:npg_Nq3k4WolyVCU@ep-cool-dawn-a15ovakh-pooler.ap-southeast-1.aws.neon.tech/neondb?sslmode=require&channel_binding=require
+# For application runtime (pooled connection)
+DATABASE_URL=postgresql://neondb_owner:npg_y8IKV9AJYwCX@ep-crimson-king-a1ws97a0-pooler.ap-southeast-1.aws.neon.tech/neondb?sslmode=require&channel_binding=require
+
+# For migrations and drizzle-kit (direct connection - use port 5432)
+DIRECT_DATABASE_URL=postgresql://neondb_owner:npg_y8IKV9AJYwCX@ep-crimson-king-a1ws97a0.ap-southeast-1.aws.neon.tech:5432/neondb?sslmode=require
+
 PGHOST=localhost
 PGPORT=5439
 PGDATABASE=pawherelandingpage

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,7 +1,14 @@
 import { defineConfig } from "drizzle-kit";
+import * as dotenv from 'dotenv';
 
-if (!process.env.DATABASE_URL) {
-  throw new Error("DATABASE_URL, ensure the database is provisioned");
+// Load environment variables
+dotenv.config();
+
+// Use direct connection for drizzle-kit, fallback to regular DATABASE_URL
+const databaseUrl = process.env.DIRECT_DATABASE_URL || process.env.DATABASE_URL;
+
+if (!databaseUrl) {
+  throw new Error("DATABASE_URL or DIRECT_DATABASE_URL must be set in environment variables");
 }
 
 export default defineConfig({
@@ -9,6 +16,6 @@ export default defineConfig({
   schema: "./shared/schema.ts",
   dialect: "postgresql",
   dbCredentials: {
-    url: process.env.DATABASE_URL,
+    url: databaseUrl,
   },
 });


### PR DESCRIPTION
changed neon account and fixed database issues

## Summary by Sourcery

Update drizzle-kit configuration to use dotenv for environment variable loading, support a direct database URL fallback, and enforce presence of a database connection URL.

Enhancements:
- Load environment variables in drizzle.config.ts using dotenv
- Add DIRECT_DATABASE_URL fallback for database connection
- Improve error handling to require either DATABASE_URL or DIRECT_DATABASE_URL